### PR TITLE
Add basic Express server for individual word pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "monese",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^5.1.0"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,42 @@
+const express = require('express');
+const path = require('path');
+const mots = require('./mots.json');
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+// Serve static assets
+app.use('/css', express.static(path.join(__dirname, 'css')));
+app.use('/js', express.static(path.join(__dirname, 'js')));
+app.use('/html', express.static(path.join(__dirname, 'html')));
+
+app.get('/:mot.html', (req, res) => {
+  const requested = req.params.mot.toLowerCase();
+  const entry = mots.find((m) => m.Mot.toLowerCase() === requested);
+  if (!entry) {
+    res.status(404).send('Mot introuvable');
+    return;
+  }
+  res.send(`<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>${entry.Mot}</title>
+  <link rel="stylesheet" href="/css/motAleatoire.css">
+</head>
+<body>
+  <h1>Monèse</h1>
+  <div class="word-card">
+    <h2>${entry.Mot.charAt(0).toUpperCase() + entry.Mot.slice(1)}</h2>
+    <p><strong>Définition :</strong> ${entry["Définition"]}</p>
+    <p><strong>Exemple :</strong> ${entry["Exemple"]}</p>
+    <span class="tag">${entry.Type}</span>
+    <span class="tag">Difficulté : ${entry["Difficulté"]}</span>
+  </div>
+</body>
+</html>`);
+});
+
+app.listen(port, () => {
+  console.log(`Server started on http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- add `.gitignore`
- add `package.json` with express dependency and start script
- create `server.js` implementing an Express server serving `/mot.html` pages

## Testing
- `node server.js` and curl `http://localhost:3000/bucolique.html`

------
https://chatgpt.com/codex/tasks/task_e_6870b25fbbfc8327a9329dc4d00f811a